### PR TITLE
docs: fix missing request in logger sample

### DIFF
--- a/website/docs/application.md
+++ b/website/docs/application.md
@@ -39,7 +39,7 @@ const app = new Sunder();
 app.use(async (ctx, next) => {
   await next();
   const rt = ctx.response.get('X-Response-Time');
-  console.log(`${ctx.method} ${ctx.url} - ${rt}`);
+  console.log(`${ctx.request.method} ${ctx.url} - ${rt}`);
 });
 
 // x-response-time


### PR DESCRIPTION
There is `ctx.method`