### PR TITLE
fix: PathParams type

### DIFF
--- a/lib/middleware/router.ts
+++ b/lib/middleware/router.ts
@@ -40,24 +40,33 @@ export type RouteHandlerMatch<S extends string> = {
   matches?: RegExpExecArray;
 } & Route<Handler<PathParams<S>>>;
 
-/** Split type `"one/two/three"` into `["one", "two", "three"]` */
+/** Split type `"one/:two/:three?/:four"` into `["one", ":two", ":three?", ":four"]` */
 type SplitPath<S extends string> =
     string extends S ? string[] :
     S extends `${infer A}/${infer B}` ? [A, ...SplitPath<B>] :
     [S];
 
-/** Convert type `"one" | ":two" | ":three"` into `"two" | "three"` */
-type ExtractParams<S extends string> =
+/** Convert type `"one" | ":two" | ":three?" | ":four"` into `"two" | "four"` */
+type ExtractRequiredParams<S extends string> =
     string extends S ? string :
+    S extends `:${infer A}?` ? never :
     S extends `:${infer A}` ? A :
     never;
 
+/** Convert type `"one" | ":two" | ":three?" | ":four"` into `"three"` */
+type ExtractOptionalParams<S extends string> =
+    string extends S ? string :
+    S extends `:${infer A}?` ? A :
+    never;
+
 /** 
- * Convert a route path string literal type such as "one/:two/:three" 
- * into a params interface like `{ two: string; three: string }`
+ * Convert a route path string literal type such as "one/:two/:three?/:four" 
+ * into a params interface like `{ two: string; three?: string; four: string }`
  */
-export type PathParams<S extends string> = {
-    [P in ExtractParams<SplitPath<S>[number]>]: string;
+ export type PathParams<S extends string> = {
+  [P in ExtractRequiredParams<SplitPath<S>[number]>]: string;
+} & {
+  [P in ExtractOptionalParams<SplitPath<S>[number]>]?: string;
 };
 
 /**

--- a/lib/middleware/router.ts
+++ b/lib/middleware/router.ts
@@ -40,20 +40,25 @@ export type RouteHandlerMatch<S extends string> = {
   matches?: RegExpExecArray;
 } & Route<Handler<PathParams<S>>>;
 
-export type SplitRoute<S extends string> = string extends S ? string[]
-  : S extends `${infer Start}/:${infer Param}/${infer Rest}`
-    ? [Param, ...SplitRoute<Rest>]
-  : S extends `${infer Start}/:${infer Param}+` ? [Param]
-  : S extends `${infer Start}/:${infer Param}` ? [Param]
-  : [];
+/** Split type `"one/two/three"` into `["one", "two", "three"]` */
+type SplitPath<S extends string> =
+    string extends S ? string[] :
+    S extends `${infer A}/${infer B}` ? [A, ...SplitPath<B>] :
+    [S];
 
-export type PathParams<S extends string> =
-  & {
-    [P in SplitRoute<S>[number]]: string;
-  }
-  & {
-    [P in SplitRoute<S>[number]]?: string;
-  };
+/** Convert type `"one" | ":two" | ":three"` into `"two" | "three"` */
+type ExtractParams<S extends string> =
+    string extends S ? string :
+    S extends `:${infer A}` ? A :
+    never;
+
+/** 
+ * Convert a route path string literal type such as "one/:two/:three" 
+ * into a params interface like `{ two: string; three: string }`
+ */
+export type PathParams<S extends string> = {
+    [P in ExtractParams<SplitPath<S>[number]>]: string;
+};
 
 /**
  * Router wraps the tiny-request-router `Router` with a more strict RouteHandler type and automatic params typings.


### PR DESCRIPTION
_This pull request fixes the `PathParams` type._

[The example](https://sunderjs.com/docs/middleware-router#route-parameters) shown in the docs has a type error in Typescript 4.4/4.5.

```ts
type Params = PathParams<"/greeting/:firstName/:lastName">;
// => { firstName: string; } & { firstName?: string | undefined; }
```

The expected type should include `lastName: string`.

[Here's a typescript playground reproduction](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBAE2AYwDYEMrDjAnmbAZTFQEsYAlCAVxmAB5C5Q6A7BAZzg5ilNYDmAPjgBebr34DmINpzhMA-BL6CA2gF04ALgUy5XAAYASAN78AZsCgKYmGAF8A9NrOXrcAAqZ0AW2durFY2FMA8DoZwymreUH4ANHAAdCnEZJQ0dPShPEJaukwswOxGgcG29s6u5kEesX4OANSR0fW++XpFJXAmNeWEdrBVZXU+-i1wMWMdmgDcAFCgkLCIKBhYOPjY3jAAFm0cjPrF8jyqwmJwpvNwt5OecPwKJORUtAyEQmqs1L4ARtYNBpdGcpAsHHAAGRXG53GKPVjPdJvLKfb6-AFQIGKEGSQTghbzPAELxjLjiHb7Mn0ABETgEWGAMCkLgspCgPAAcn5gC4MFyeTShAsgA).

This merge request fixes the issue so that PathParams is properly typed.

As a side note, it's unclear why `PathParams` is defined as

```ts
export declare type PathParams<S extends string> = {
    [P in SplitRoute<S>[number]]: string;
} & {
    [P in SplitRoute<S>[number]]?: string;
};
```

instead of simply

```ts
export declare type PathParams<S extends string> = {
    [P in SplitRoute<S>[number]]: string;
};
```

Since `{someKey: string} & {someKey?: string}` is always equivalent to just `{someKey: string}`.